### PR TITLE
lgtm fixes

### DIFF
--- a/src/itsa.c
+++ b/src/itsa.c
@@ -463,9 +463,10 @@ static void print_bread_crumb(const char *bread_crumb[])
 		return;
 	}
 
-	for ( ; *bread_crumb != NULL; bread_crumb++)
-		len += snprintf(str + len, sizeof(str) - len, "%s / ",
-				*bread_crumb);
+	for ( ; *bread_crumb != NULL; bread_crumb++) {
+		snprintf(str + len, sizeof(str) - len, "%s / ", *bread_crumb);
+		len = strlen(str);
+	}
 	str[len - 3] = '\0';
 	printc("#BOLD# %s#RST#\n", str);
 }


### PR DESCRIPTION
This is a couple of fixes for issues found with LGTM.

The first is to fix some potential SQL injection issues. In reality these were unlikely to be a problem, but might as well close that hole.

The second is to avoid a potential overflow from snprintf(3) by not taking into account that the return value from snprintf _could_ be larger than the buffer it's writing into.