### PR TITLE
Setup GitHub Actions

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -1,0 +1,134 @@
+name: Builds
+
+on:
+  push:
+    branches: master
+    paths:
+      - Makefile
+      - 'src/**'
+      - '.github/workflows/**'
+  pull_request:
+    branches: master
+    paths:
+      - Makefile
+      - 'src/**'
+      - '.github/workflows/**'
+
+jobs:
+  # GitHub Currently only supports running directly on Ubuntu,
+  # for any other Linux we need to use a container.
+
+  # CentOS 7 / glibc 2.17 / gcc 4.8.5
+  centos_7:
+    runs-on: ubuntu-latest
+
+    container:
+      image: centos:7
+
+    steps:
+      - name: Install tools/deps
+        run: |
+          yum -y install git gcc make jansson-devel libcurl-devel sqlite-devel
+          git clone https://github.com/ac000/libmtdac.git ${RUNNER_TEMP}/libmtdac
+          cd ${RUNNER_TEMP}/libmtdac/src
+          make
+          cd -
+          git clone https://github.com/ac000/libac.git ${RUNNER_TEMP}/libac
+          cd ${RUNNER_TEMP}/libac/src
+          make
+          export LD_LIBRARY_PATH="${RUNNER_TEMP}/libmtdac/src:${RUNNER_TEMP}/libac/src"
+
+      - uses: actions/checkout@v2
+
+      - name: make
+        # Fudge the version seeing as we don't actually have a git
+        # repository here due to needing git 2.18+. The version
+        # number is not actually important to just test the build.
+        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make -C src/ GIT_VERSION=\\\"v0.0.0\\\" V=1
+
+  # CentOS 8 / glibc 2.28 / gcc 8.4.1
+  centos_8:
+    runs-on: ubuntu-latest
+
+    container:
+      image: centos:8
+
+    steps:
+      - name: Install tools/deps
+        run: |
+          yum -y install git gcc make jansson-devel libcurl-devel sqlite-devel
+          git clone https://github.com/ac000/libmtdac.git ${RUNNER_TEMP}/libmtdac
+          cd ${RUNNER_TEMP}/libmtdac/src
+          make
+          cd -
+          git clone https://github.com/ac000/libac.git ${RUNNER_TEMP}/libac
+          cd ${RUNNER_TEMP}/libac/src
+          make
+          export LD_LIBRARY_PATH="${RUNNER_TEMP}/libmtdac/src:${RUNNER_TEMP}/libac/src"
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+
+      - name: make
+        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make -C src/ V=1
+
+  # Debian 11 / glibc 2.31 / gcc 10.2
+  debian_11:
+    runs-on: ubuntu-latest
+
+    container:
+      image: debian:11
+
+    steps:
+      - name: Install deps
+        run: |
+          apt-get -y update
+          apt-get -y install git gcc make libjansson-dev libcurl4-openssl-dev libsqlite3-dev
+          git clone https://github.com/ac000/libmtdac.git ${RUNNER_TEMP}/libmtdac
+          cd ${RUNNER_TEMP}/libmtdac/src
+          make
+          cd -
+          git clone https://github.com/ac000/libac.git ${RUNNER_TEMP}/libac
+          cd ${RUNNER_TEMP}/libac/src
+          make
+          export LD_LIBRARY_PATH="${RUNNER_TEMP}/libmtdac/src:${RUNNER_TEMP}/libac/src"
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+
+      - name: make
+        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make -C src/ V=1
+
+  # Fedora 34 / glibc 2.33 / gcc 11.2 / clang 12.0
+  fedora_34:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ gcc, clang ]
+
+    container:
+      image: fedora:34
+
+    steps:
+      - name: Install tools/deps
+        run: |
+          dnf -y install git ${{ matrix.compiler }} make jansson-devel libcurl-devel sqlite-devel
+          git clone https://github.com/ac000/libmtdac.git ${RUNNER_TEMP}/libmtdac
+          cd ${RUNNER_TEMP}/libmtdac/src
+          make CC=${{ matrix.compiler }}
+          cd -
+          git clone https://github.com/ac000/libac.git ${RUNNER_TEMP}/libac
+          cd ${RUNNER_TEMP}/libac/src
+          make CC=${{ matrix.compiler }}
+          export LD_LIBRARY_PATH="${RUNNER_TEMP}/libmtdac/src:${RUNNER_TEMP}/libac/src"
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+
+      - name: make CC=${{ matrix.compiler }}
+        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make -C src/ CC=${{ matrix.compiler }} V=1


### PR DESCRIPTION
This adds an initial GitHub Actions Workflow.

It currently does builds under CentOS 7 & 8 with GCC, Debian 11 with GCC
and Fedora 34 with GCC & clang. All x86-64.

It uses docker containers as GitHub only supports directly running on
Ubuntu (as far as Linux is concerned).

It will run the build tests on pull-requests and pushes to master.

It should only trigger on updates to; Makefile, src/ &
.github/workflows/

It adds -Werror to the CFLAGS to try and keep a warning free build.