### PR TITLE
Makefile and build updates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,4 +25,4 @@ task:
     gmake CC=clang
     export LD_LIBRARY_PATH="${CIRRUS_WORKING_DIR}/libmtdac/src:${CIRRUS_WORKING_DIR}/libac/src"
     cd ${CIRRUS_WORKING_DIR}
-    CFLAGS="-I${CIRRUS_WORKING_DIR}/libmtdac/include -I${CIRRUS_WORKING_DIR}/libac/src/include -Werror" LDFLAGS="-L${CIRRUS_WORKING_DIR}/libmtdac/src -L${CIRRUS_WORKING_DIR}/libac/src" gmake -C src/ CC=clang V=1
+    CFLAGS="-I${CIRRUS_WORKING_DIR}/libmtdac/include -I${CIRRUS_WORKING_DIR}/libac/src/include -Werror" LDFLAGS="-L${CIRRUS_WORKING_DIR}/libmtdac/src -L${CIRRUS_WORKING_DIR}/libac/src" gmake CC=clang V=1

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -44,7 +44,7 @@ jobs:
         # Fudge the version seeing as we don't actually have a git
         # repository here due to needing git 2.18+. The version
         # number is not actually important to just test the build.
-        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make -C src/ GIT_VERSION=\\\"v0.0.0\\\" V=1
+        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make GIT_VERSION=\\\"v0.0.0\\\" V=1
 
   # CentOS 8 / glibc 2.28 / gcc 8.4.1
   centos_8:
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: "0"
 
       - name: make
-        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make -C src/ V=1
+        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make V=1
 
   # Debian 11 / glibc 2.31 / gcc 10.2
   debian_11:
@@ -99,7 +99,7 @@ jobs:
           fetch-depth: "0"
 
       - name: make
-        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make -C src/ V=1
+        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make V=1
 
   # Fedora 34 / glibc 2.33 / gcc 11.2 / clang 12.0
   fedora_34:
@@ -131,4 +131,4 @@ jobs:
           fetch-depth: "0"
 
       - name: make CC=${{ matrix.compiler }}
-        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make -C src/ CC=${{ matrix.compiler }} V=1
+        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -I${RUNNER_TEMP}/libac/src/include -Werror" LDFLAGS="-L${RUNNER_TEMP}/libmtdac/src -L${RUNNER_TEMP}/libac/src" make CC=${{ matrix.compiler }} V=1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+TARGETS = itsa hdrchk
+
+.PHONY: all $(TARGETS)
+all: $(TARGETS)
+
+MAKE_OPTS = --no-print-directory V=$V
+
+.PHONY: itsa
+itsa:
+	@echo -e "Building: itsa"
+	@$(MAKE) $(MAKE_OPTS) -C src/
+
+.PHONY: hdrchk
+hdrchk:
+	@echo -e "Checking Headers"
+	@$(MAKE) $(MAKE_OPTS) -C src/ hdrchk
+
+.PHONY: clean
+clean:
+	@echo -e "Cleaning: itsa"
+	@$(MAKE) $(MAKE_OPTS) -C src/ clean

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,6 @@
 .d/
 
 *.o
+*.gch
 
 itsa

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ GIT_VERSION = \"$(shell git describe --always --long --dirty --all)\"
 
 DEPDIR  := .d
 $(shell mkdir -p $(DEPDIR) >/dev/null)
-DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
+DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$(@F).Td
 
 CC	= gcc
 CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla -std=gnu99 -g -O2 \
@@ -13,11 +13,9 @@ CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla -std=gnu99 -g -O2 \
 	  -DGIT_VERSION=${GIT_VERSION} -pipe
 LDFLAGS += -L../../libmtdac/src -Wl,-z,now,-z,defs,-z,relro,--as-needed -pie
 LIBS	+= -lmtdac -lac -lsqlite3 -ljansson
-POSTCOMPILE = @mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d && touch $@
+POSTCOMPILE = @mv -f $(DEPDIR)/$(@F).Td $(DEPDIR)/$(@F).d && touch $@
 
-COMPILER := $(shell $(CC) --version 2> /dev/null | grep -oE 'GCC|clang')
-
-ifeq "$(COMPILER)" "GCC"
+ifeq ($(CC),gcc)
         GCC_MAJOR  := $(shell gcc -dumpfullversion -dumpversion | cut -d . -f 1)
         GCC_MINOR  := $(shell gcc -dumpfullversion -dumpversion | cut -d . -f 2)
         GCC_SUB	   := $(shell gcc -dumpfullversion -dumpversion | cut -d . -f 3)
@@ -55,18 +53,29 @@ $(APP): $(objects)
 	$(v)$(CC) $(LDFLAGS) $(ASAN) -o $@ $(objects) $(LIBS)
 
 %.o: %.c
-%.o: %.c $(DEPDIR)/%.d
+%.o: %.c $(DEPDIR)/%.o.d
 	@echo -e "  CC\t$@"
+	$(v)$(CC) $(DEPFLAGS) $(CFLAGS) -c -o $@ $<
+	$(POSTCOMPILE)
+
+headers := $(wildcard *.h)
+hdrobjs := $(headers:.h=.gch)
+
+hdrchk: $(hdrobjs)
+%.gch: %.h
+%.gch: %.h $(DEPDIR)/%.gch.d
+	@echo -e "  CC\t$<"
 	$(v)$(CC) $(DEPFLAGS) $(CFLAGS) -c -o $@ $<
 	$(POSTCOMPILE)
 
 $(DEPDIR)/%.d: ;
 .PRECIOUS: $(DEPDIR)/%.d
 
-include $(wildcard $(patsubst %,$(DEPDIR)/%.d,$(basename $(sources))))
+include $(wildcard $(patsubst %,$(DEPDIR)/%.o.d,$(basename $(sources))))
+include $(wildcard $(patsubst %,$(DEPDIR)/%.gch.d,$(basename $(headers))))
 
 .PHONY: clean
 clean:
-	$(v)rm -f $(objects) $(APP)
+	$(v)rm -f $(objects) $(hdrobjs) $(APP)
 	$(v)rm -f $(DEPDIR)/*
 	$(v)rmdir $(DEPDIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,10 +7,11 @@ $(shell mkdir -p $(DEPDIR) >/dev/null)
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$(@F).Td
 
 CC	= gcc
-CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla -std=gnu99 -g -O2 \
-	  -Wp,-D_FORTIFY_SOURCE=2 --param=ssp-buffer-size=4 -fstack-protector \
-	  -fPIE -fexceptions -I../../libmtdac/include \
-	  -DGIT_VERSION=${GIT_VERSION} -pipe
+CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla \
+	  -Wmissing-prototypes -Wstrict-prototypes -Wold-style-definition \
+	  -std=gnu99 -g -O2 -Wp,-D_FORTIFY_SOURCE=2 --param=ssp-buffer-size=4 \
+	  -fno-common -fstack-protector -fPIE -fexceptions \
+	  -I../../libmtdac/include -DGIT_VERSION=${GIT_VERSION} -pipe
 LDFLAGS += -L../../libmtdac/src -Wl,-z,now,-z,defs,-z,relro,--as-needed -pie
 LIBS	+= -lmtdac -lac -lsqlite3 -ljansson
 POSTCOMPILE = @mv -f $(DEPDIR)/$(@F).Td $(DEPDIR)/$(@F).d && touch $@


### PR DESCRIPTION
The first commit adds a 'hdrchk' target to the Makefile. This will build each header individually to check that they are self-contained and contain everything they need.

The second commit adds some extra compiler flags; -Wmissing-prototypes -Wstrict-prototypes -Wold-style-definition -fno-common, to help enforce coding style and correctness

The third commit adds a top level makefile, by default it will build itsa and do the headers build check.

The fourth commit switches the CI builds over to using the top-level makefile.

