### PR TITLE
itsa: Display a started at time

### DIFF
--- a/src/itsa.c
+++ b/src/itsa.c
@@ -2337,6 +2337,10 @@ static int do_init_all(const struct mtd_cfg *cfg)
 
 static void print_api_info(void)
 {
+	struct timespec tp;
+	struct tm tm;
+	char buf[32] = "\0";
+
 	printic("***\n");
 	printic("*** Using %s API\n",
 		is_prod_api ? "#RED#PRODUCTION#RST#" : "#TANG#TEST#RST#");
@@ -2345,6 +2349,12 @@ static void print_api_info(void)
 		goto out;
 	printic("*** Using business : #BOLD#%s#RST# [#BOLD#%s#RST#]\n",
 		BUSINESS_NAME, BUSINESS_ID);
+	printic("***\n");
+
+	clock_gettime(CLOCK_REALTIME, &tp);
+	localtime_r(&tp.tv_sec, &tm);
+	strftime(buf, sizeof(buf), "%FT%T", &tm);
+	printic("*** Started @ #BOLD#%s#RST#\n", buf);
 	printic("***\n");
 
 out:


### PR DESCRIPTION
At start up, display a datestamp like

    [INFO] *** Started @ 2021-12-27T15:40:17

This may be useful when logging the output to have a record of the
date/time when it was run.
