### PR TITLE
Fix a couple of compiler warnings

### DIFF
--- a/src/itsa.c
+++ b/src/itsa.c
@@ -1906,6 +1906,8 @@ static int dispatcher(int argc, char *argv[], const struct mtd_cfg *cfg)
 
 static const FILE *set_log_fp(const char *log_level)
 {
+	FILE *fp;
+	char *ll;
 	char *ptr;
 	char *ptrm;
 	const char *mode = "we";
@@ -1913,10 +1915,14 @@ static const FILE *set_log_fp(const char *log_level)
 	if (!log_level || !strchr(log_level, ':'))
 		return NULL;
 
-	ptr = strchr(log_level, ':');
+	ll = strdup(log_level);
+	if (!ll)
+		return NULL;
+
+	ptr = strchr(ll, ':');
 	ptr++;
 
-	ptrm = strchr(log_level, '+');
+	ptrm = strchr(ll, '+');
 	if (!ptrm)
 		goto out;
 
@@ -1926,7 +1932,10 @@ static const FILE *set_log_fp(const char *log_level)
 		mode = "ae";
 
 out:
-	return fopen(ptr, mode);
+	fp = fopen(ptr, mode);
+	free(ll);
+
+	return fp;
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
GCC 16 was throwing

itsa.c: In function ‘set_log_fp’:
itsa.c:1916:13: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 1916 |         ptr = strchr(log_level, ':');
      |             ^
itsa.c:1919:14: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 1919 |         ptrm = strchr(log_level, '+');
      |              ^

This is due to a change with C23 where a bunch of string functions now use the QChar* type-generic placeholder, e.g.

  QChar *strchr(QChar *s, int c);

So that if you pass in a const-qualified char you get back a const-qualified char.

The fix here is to take a copy of log_level, as we may actually modify it through the non-const ptrm pointer, and operate on that instead.

Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3020.pdf>
Link: <https://thephd.dev/c23-is-coming-here-is-what-is-on-the-menu#n3020---qualifier-preserving-standard-functions>